### PR TITLE
feat: support dotnet

### DIFF
--- a/collect_repos.py
+++ b/collect_repos.py
@@ -90,8 +90,6 @@ class CollectReposStrategy(RepoStrategy):
                     act_run = actions.run_workflow(
                         actions.test_workflows[0], act_cache_dir=act_cache_dir
                     )
-                    print(actions.test_workflows[0].doc)
-                    print(act_run.asdict()["stdout"])
                 finally:
                     ActCacheDirManager.return_act_cache_dir(act_cache_dir)
 

--- a/collect_repos.py
+++ b/collect_repos.py
@@ -21,6 +21,7 @@ from gitbugactions.actions.actions import (
 from gitbugactions.crawler import RepoCrawler, RepoStrategy
 from gitbugactions.infra.infra_checkers import is_infra_file
 from gitbugactions.utils.repo_utils import clone_repo, delete_repo_clone
+from gitbugactions.github_api import GithubAPI
 
 
 class CollectReposStrategy(RepoStrategy):
@@ -66,7 +67,7 @@ class CollectReposStrategy(RepoStrategy):
         try:
             data["clone_success"] = True
 
-            actions = GitHubActions(repo_path, repo.language)
+            actions = GitHubActions(repo_path, repo.language, github_api=None)
             data["number_of_actions"] = len(actions.workflows)
             data["actions_build_tools"] = [
                 x.get_build_tool() for x in actions.workflows
@@ -112,7 +113,7 @@ class CollectInfraReposStrategy(CollectReposStrategy):
         super().__init__(data_path)
 
     def test_actions(self, data: dict, repo: Repository, repo_path: str):
-        actions = GitHubActions(repo_path, repo.language)
+        actions = GitHubActions(repo_path, repo.language, github_api=None)
         data["number_of_actions"] = len(actions.workflows)
         data["actions_build_tools"] = [x.get_build_tool() for x in actions.workflows]
         data["number_of_test_actions"] = len(actions.test_workflows)

--- a/collect_repos.py
+++ b/collect_repos.py
@@ -21,7 +21,6 @@ from gitbugactions.actions.actions import (
 from gitbugactions.crawler import RepoCrawler, RepoStrategy
 from gitbugactions.infra.infra_checkers import is_infra_file
 from gitbugactions.utils.repo_utils import clone_repo, delete_repo_clone
-from gitbugactions.github_api import GithubAPI
 
 
 class CollectReposStrategy(RepoStrategy):
@@ -67,7 +66,7 @@ class CollectReposStrategy(RepoStrategy):
         try:
             data["clone_success"] = True
 
-            actions = GitHubActions(repo_path, repo.language, github_api=None)
+            actions = GitHubActions(repo_path, repo.language)
             data["number_of_actions"] = len(actions.workflows)
             data["actions_build_tools"] = [
                 x.get_build_tool() for x in actions.workflows
@@ -91,6 +90,8 @@ class CollectReposStrategy(RepoStrategy):
                     act_run = actions.run_workflow(
                         actions.test_workflows[0], act_cache_dir=act_cache_dir
                     )
+                    print(actions.test_workflows[0].doc)
+                    print(act_run.asdict()["stdout"])
                 finally:
                     ActCacheDirManager.return_act_cache_dir(act_cache_dir)
 
@@ -113,7 +114,7 @@ class CollectInfraReposStrategy(CollectReposStrategy):
         super().__init__(data_path)
 
     def test_actions(self, data: dict, repo: Repository, repo_path: str):
-        actions = GitHubActions(repo_path, repo.language, github_api=None)
+        actions = GitHubActions(repo_path, repo.language)
         data["number_of_actions"] = len(actions.workflows)
         data["actions_build_tools"] = [x.get_build_tool() for x in actions.workflows]
         data["number_of_test_actions"] = len(actions.test_workflows)

--- a/export_bugs.py
+++ b/export_bugs.py
@@ -66,7 +66,9 @@ def create_exported_containers(
                     container.remove(v=True, force=True)
                     continue
             diff_file_path = os.path.join(diff_folder_path, container.name)
-            extract_diff(container.id, diff_file_path, ignore_paths=["/tmp"])
+            extract_diff(
+                container.id, diff_file_path, ignore_paths=["/tmp/*", "*.act-result*"]
+            )
             container.remove(v=True, force=True)
 
             workflows = os.path.join(diff_folder_path, "workflow")

--- a/filter_bugs.py
+++ b/filter_bugs.py
@@ -21,6 +21,7 @@ from gitbugactions.docker.client import DockerClient
 from gitbugactions.docker.export import create_diff_image
 from gitbugactions.test_executor import TestExecutor
 from gitbugactions.utils.repo_utils import delete_repo_clone
+from gitbugactions.utils.repo_state_manager import RepoStateManager
 from run_bug import get_default_actions, get_diff_path
 
 
@@ -34,6 +35,9 @@ def run_commit(
 ) -> Optional[List[ActTestsRun]]:
     act_cache_dir = ActCacheDirManager.acquire_act_cache_dir()
     try:
+        # FIXME: we shouldn't need to call this here, but we have to do it because the get_default_actions script will inspect the repo state
+        RepoStateManager.reset_to_commit(repo_clone, bug.commit)
+
         executor = TestExecutor(
             repo_clone,
             bug.language,
@@ -186,7 +190,7 @@ def filter_bug(
         else:
             return "NON-FLAKY"
     finally:
-        delete_repo_clone(repo_clone)
+        # delete_repo_clone(repo_clone)
         docker_client.images.remove(image_name, force=True)
 
 
@@ -250,7 +254,8 @@ def filter_bugs(
                     )
                     future_to_bug[future] = bug
             finally:
-                delete_repo_clone(repo_clone)
+                # delete_repo_clone(repo_clone)
+                pass
 
         for future in tqdm.tqdm(as_completed(future_to_bug), total=len(future_to_bug)):
             try:

--- a/gitbugactions/actions/actions.py
+++ b/gitbugactions/actions/actions.py
@@ -385,6 +385,7 @@ class GitHubActions:
         runner_image: str = "gitbugactions:latest",
         offline: bool = False,
         base_image: str | None = None,
+        github_api=None,
     ):
         self.repo_path = repo_path
         self.keep_containers = keep_containers
@@ -394,6 +395,7 @@ class GitHubActions:
         self.runner_image = runner_image
         self.offline = offline
         self.base_image = base_image
+        self.github_api = github_api
 
         workflows_path = os.path.join(repo_path, ".github", "workflows")
         for dirpath, dirnames, filenames in os.walk(workflows_path):
@@ -419,7 +421,18 @@ class GitHubActions:
                 workflow.instrument_jobs()
                 workflow.instrument_cache_steps()
                 workflow.instrument_setup_steps()
-                workflow.instrument_test_steps()
+
+                # Pass GitHub API to instrument_test_steps if method accepts it
+                if hasattr(workflow, "instrument_test_steps"):
+                    if self.github_api and hasattr(workflow, "get_project_structure"):
+                        try:
+                            workflow.instrument_test_steps(self.github_api)
+                        except TypeError:
+                            # Fallback if method doesn't accept github_api parameter
+                            workflow.instrument_test_steps()
+                    else:
+                        workflow.instrument_test_steps()
+
                 if offline:
                     workflow.instrument_offline_execution()
                 else:

--- a/gitbugactions/actions/actions.py
+++ b/gitbugactions/actions/actions.py
@@ -385,7 +385,6 @@ class GitHubActions:
         runner_image: str = "gitbugactions:latest",
         offline: bool = False,
         base_image: str | None = None,
-        github_api=None,
     ):
         self.repo_path = repo_path
         self.keep_containers = keep_containers
@@ -395,7 +394,6 @@ class GitHubActions:
         self.runner_image = runner_image
         self.offline = offline
         self.base_image = base_image
-        self.github_api = github_api
 
         workflows_path = os.path.join(repo_path, ".github", "workflows")
         for dirpath, dirnames, filenames in os.walk(workflows_path):
@@ -422,11 +420,12 @@ class GitHubActions:
                 workflow.instrument_cache_steps()
                 workflow.instrument_setup_steps()
 
-                # Pass GitHub API to instrument_test_steps if method accepts it
+                # Instrument test steps if the workflow has a get_project_structure method
+                # HACK: This is used to instrument .NET test steps
                 if hasattr(workflow, "instrument_test_steps"):
-                    if self.github_api and hasattr(workflow, "get_project_structure"):
+                    if hasattr(workflow, "get_project_structure"):
                         try:
-                            workflow.instrument_test_steps(self.github_api)
+                            workflow.instrument_test_steps(self.repo_path)
                         except TypeError:
                             # Fallback if method doesn't accept github_api parameter
                             workflow.instrument_test_steps()

--- a/gitbugactions/actions/actions.py
+++ b/gitbugactions/actions/actions.py
@@ -19,6 +19,7 @@ from gitbugactions.actions.workflow import GitHubWorkflow
 from gitbugactions.actions.workflow_factory import GitHubWorkflowFactory
 from gitbugactions.docker.client import DockerClient
 from gitbugactions.github_api import GithubToken
+from gitbugactions.utils.repo_state_manager import RepoStateManager
 
 
 class ActCacheDirManager:
@@ -321,6 +322,9 @@ class Act:
     def run_act(
         self, repo_path, workflow: GitHubWorkflow, act_cache_dir: str
     ) -> ActTestsRun:
+        # Clean up before running
+        RepoStateManager.clean_act_result_dir(repo_path)
+
         command = f"cd {repo_path}; "
         command += f"ACT_DISABLE_VERSION_CHECK=1 XDG_CACHE_HOME='{act_cache_dir}' timeout {self.timeout * 60} {Act.__ACT_PATH} {self.__DEFAULT_RUNNERS} {Act.__FLAGS} {self.flags}"
         if GithubToken.has_tokens():
@@ -481,6 +485,9 @@ class GitHubActions:
         act_fail_strategy: ActFailureStrategy = ActTestsFailureStrategy(),
         timeout: int = 10,
     ) -> ActTestsRun:
+        # Clean up before running
+        RepoStateManager.clean_act_result_dir(self.repo_path)
+
         act = Act(
             self.keep_containers,
             timeout=timeout,

--- a/gitbugactions/actions/csharp/dotnet_workflow.py
+++ b/gitbugactions/actions/csharp/dotnet_workflow.py
@@ -95,6 +95,7 @@ class DotNetWorkflow(GitHubWorkflow):
                                             "Cannot instrument test steps, no source or test directories detected"
                                         )
                                     else:
+                                        print(self.source_dirs, self.test_dirs)
                                         logger.warning(
                                             "Cannot instrument test steps, multiple source or test directories detected"
                                         )

--- a/gitbugactions/actions/csharp/dotnet_workflow.py
+++ b/gitbugactions/actions/csharp/dotnet_workflow.py
@@ -1,10 +1,14 @@
-from typing import List
+from typing import Dict, List, Optional, Set, Tuple
 from junitparser import TestCase
 from pathlib import Path
 import re
+import logging
 
 from gitbugactions.actions.workflow import GitHubWorkflow
 from gitbugactions.actions.multi.junitxmlparser import JUnitXMLParser
+from gitbugactions.actions.csharp.helpers import DotNetProjectAnalyzer
+
+logger = logging.getLogger(__name__)
 
 
 class DotNetWorkflow(GitHubWorkflow):
@@ -14,6 +18,19 @@ class DotNetWorkflow(GitHubWorkflow):
         r"dotnet\s+test",
     ]
 
+    def __init__(self, path: str, workflow: str = ""):
+        super().__init__(path, workflow)
+        self.source_dirs = None
+        self.test_dirs = None
+        self.analyzer = None
+
+        # Extract owner/name from path
+        if "/" in path:
+            self.owner, self.name = path.split("/", 1)
+        else:
+            self.owner = ""
+            self.name = path
+
     def _is_test_command(self, command) -> bool:
         # Checks if the given command matches any of the tests command patterns
         for pattern in DotNetWorkflow.__TESTS_COMMAND_PATTERNS:
@@ -21,16 +38,63 @@ class DotNetWorkflow(GitHubWorkflow):
                 return True
         return False
 
-    def instrument_test_steps(self):
+    def instrument_test_steps(self, github_api=None):
+        """
+        Instrument the test steps to capture test results.
+
+        Args:
+            github_api: Optional GitHub API instance, used for determining project structure
+        """
         # Add reporting options to the test command
         if "jobs" in self.doc:
             for _, job in self.doc["jobs"].items():
                 if "steps" in job:
                     for step in job["steps"]:
                         if "run" in step and self._is_test_command(step["run"]):
-                            step["run"] = (
-                                f'dotnet add package JUnitXml.TestLogger && {step["run"]} --logger:"junit;LogFilePath=./TestResults/test-results.xml"'
-                            )
+                            # If we have access to GitHub API, try to analyze project structure first
+                            if (
+                                github_api
+                                and not self.source_dirs
+                                and not self.test_dirs
+                            ):
+                                try:
+                                    self.get_project_structure(github_api)
+                                    logger.info(
+                                        f"Detected source directories: {self.source_dirs}"
+                                    )
+                                    logger.info(
+                                        f"Detected test directories: {self.test_dirs}"
+                                    )
+
+                                    print(self.source_dirs)
+                                    print(self.test_dirs)
+                                    if (
+                                        len(self.source_dirs) == 1
+                                        and len(self.test_dirs) == 1
+                                    ):
+                                        step["run"] = (
+                                            f'cd {self.source_dirs} && dotnet add package JUnitXml.TestLogger --version 5.0.0 && {step["run"]} --logger:"junit;LogFilePath=./TestResults/test-results.xml"'
+                                        )
+                                    elif (
+                                        len(self.source_dirs) == 0
+                                        or len(self.test_dirs) == 0
+                                    ):
+                                        logger.warning(
+                                            "Cannot instrument test steps, no source or test directories detected"
+                                        )
+                                    else:
+                                        logger.warning(
+                                            "Cannot instrument test steps, multiple source or test directories detected"
+                                        )
+
+                                except Exception as e:
+                                    logger.warning(
+                                        f"Error analyzing .NET project structure: {e}"
+                                    )
+                            else:
+                                logger.warning(
+                                    "No GitHub API available, cannot instrument test steps"
+                                )
 
     def instrument_offline_execution(self):
         pass
@@ -41,3 +105,69 @@ class DotNetWorkflow(GitHubWorkflow):
 
     def get_build_tool(self) -> str:
         return "dotnet"
+
+    def get_project_structure(self, github_api) -> Tuple[Set[str], Set[str]]:
+        """
+        Analyze repository structure to identify source and test directories without cloning.
+
+        Args:
+            github_api: Instance of GithubAPI
+
+        Returns:
+            Tuple[Set[str], Set[str]]: Sets of source and test directory paths
+        """
+        if self.source_dirs is not None and self.test_dirs is not None:
+            return self.source_dirs, self.test_dirs
+
+        try:
+            # Create analyzer if not exists
+            if self.analyzer is None:
+                self.analyzer = DotNetProjectAnalyzer(github_api)
+
+            # Analyze repository structure
+            repo_name = self.path  # path should already be in format "owner/repo"
+            self.source_dirs, self.test_dirs = self.analyzer.analyze_repository(
+                repo_name
+            )
+
+            logger.info(f"Identified source directories: {self.source_dirs}")
+            logger.info(f"Identified test directories: {self.test_dirs}")
+
+            # Handle edge cases where analysis didn't yield results
+            if not self.source_dirs and not self.test_dirs:
+                # If we couldn't find any directories, use reasonable defaults
+                self.source_dirs = {"src", "."}
+                self.test_dirs = {"test", "tests"}
+                logger.warning("Using default source and test directories")
+
+            return self.source_dirs, self.test_dirs
+        except Exception as e:
+            logger.error(f"Error analyzing .NET project structure: {e}")
+            # Return reasonable defaults on error
+            return {"src", "."}, {"test", "tests"}
+
+    def get_source_directories(self, github_api) -> Set[str]:
+        """
+        Get source code directories from the repository.
+
+        Args:
+            github_api: Instance of GithubAPI
+
+        Returns:
+            Set[str]: Set of source directory paths
+        """
+        source_dirs, _ = self.get_project_structure(github_api)
+        return source_dirs
+
+    def get_test_directories(self, github_api) -> Set[str]:
+        """
+        Get test directories from the repository.
+
+        Args:
+            github_api: Instance of GithubAPI
+
+        Returns:
+            Set[str]: Set of test directory paths
+        """
+        _, test_dirs = self.get_project_structure(github_api)
+        return test_dirs

--- a/gitbugactions/actions/csharp/dotnet_workflow.py
+++ b/gitbugactions/actions/csharp/dotnet_workflow.py
@@ -1,0 +1,43 @@
+from typing import List
+from junitparser import TestCase
+from pathlib import Path
+import re
+
+from gitbugactions.actions.workflow import GitHubWorkflow
+from gitbugactions.actions.multi.junitxmlparser import JUnitXMLParser
+
+
+class DotNetWorkflow(GitHubWorkflow):
+    BUILD_TOOL_KEYWORDS = {"dotnet", "vstest"}
+    # Regex patterns to match .NET test commands
+    __TESTS_COMMAND_PATTERNS = [
+        r"dotnet\s+test",
+    ]
+
+    def _is_test_command(self, command) -> bool:
+        # Checks if the given command matches any of the tests command patterns
+        for pattern in DotNetWorkflow.__TESTS_COMMAND_PATTERNS:
+            if re.search(pattern, command):
+                return True
+        return False
+
+    def instrument_test_steps(self):
+        # Add reporting options to the test command
+        if "jobs" in self.doc:
+            for _, job in self.doc["jobs"].items():
+                if "steps" in job:
+                    for step in job["steps"]:
+                        if "run" in step and self._is_test_command(step["run"]):
+                            step["run"] = (
+                                f'dotnet add package JUnitXml.TestLogger && {step["run"]} --logger:"junit;LogFilePath=./TestResults/test-results.xml"'
+                            )
+
+    def instrument_offline_execution(self):
+        pass
+
+    def get_test_results(self, repo_path) -> List[TestCase]:
+        parser = JUnitXMLParser()
+        return parser.get_test_results(str(Path(repo_path, "TestResults")))
+
+    def get_build_tool(self) -> str:
+        return "dotnet"

--- a/gitbugactions/actions/csharp/helpers/__init__.py
+++ b/gitbugactions/actions/csharp/helpers/__init__.py
@@ -1,0 +1,5 @@
+from gitbugactions.actions.csharp.helpers.dotnet_project_analyzer import (
+    DotNetProjectAnalyzer,
+)
+
+__all__ = ["DotNetProjectAnalyzer"]

--- a/gitbugactions/actions/csharp/helpers/dotnet_project_analyzer.py
+++ b/gitbugactions/actions/csharp/helpers/dotnet_project_analyzer.py
@@ -1,0 +1,382 @@
+import os
+import re
+import xml.etree.ElementTree as ET
+import base64
+from typing import List, Optional, Set, Tuple
+
+
+class DotNetProjectAnalyzer:
+    """
+    Helper class for analyzing .NET project structures without cloning the repository.
+    Uses GitHub API to examine .csproj files and determine project structure.
+    """
+
+    def __init__(self, github_api):
+        """
+        Initialize with a GitHub API instance.
+
+        Args:
+            github_api: Instance of GithubAPI class
+        """
+        self.github_api = github_api
+        self.test_framework_patterns = [
+            "xunit",
+            "nunit",
+            "mstest",
+            "testingframework",
+            "test.sdk",
+        ]
+
+    def is_test_project_file(self, content: str) -> bool:
+        """
+        Determines if a .csproj file content represents a test project.
+
+        Args:
+            content: The XML content of a .csproj file
+
+        Returns:
+            bool: True if it's a test project, False otherwise
+        """
+        try:
+            # Parse XML content
+            root = ET.fromstring(content)
+
+            # Look for test framework references
+            for elem in root.iter():
+                # Check for PackageReference with test frameworks
+                if elem.tag.endswith("PackageReference"):
+                    include_attr = elem.get("Include", "").lower()
+                    if any(
+                        framework in include_attr
+                        for framework in self.test_framework_patterns
+                    ):
+                        return True
+
+                # Check for explicit IsTestProject property
+                if elem.tag.endswith("IsTestProject"):
+                    if elem.text and elem.text.strip().lower() == "true":
+                        return True
+
+            return False
+        except Exception as e:
+            print(f"Error parsing project file: {e}")
+            return False
+
+    def has_test_file_naming_pattern(self, files: List[str]) -> bool:
+        """
+        Checks if any files in the directory follow test naming conventions.
+
+        Args:
+            files: List of file names in a directory
+
+        Returns:
+            bool: True if test files are found, False otherwise
+        """
+        test_patterns = [r"test\.cs$", r"tests\.cs$", r"test_", r"tests_"]
+        for file in files:
+            if any(re.search(pattern, file.lower()) for pattern in test_patterns):
+                return True
+        return False
+
+    def analyze_repository(
+        self, repo_name: str, max_files: int = 100
+    ) -> Tuple[Set[str], Set[str]]:
+        """
+        Analyzes a GitHub repository to identify source and test directories.
+        Uses multiple strategies to efficiently identify project structure.
+
+        Args:
+            repo_name: The repository name in format "owner/repo"
+            max_files: Maximum number of files to analyze to prevent rate limiting
+
+        Returns:
+            Tuple[Set[str], Set[str]]: Sets of source and test directory paths
+        """
+        repo = self.github_api.get_repo(repo_name)
+        source_dirs = set()
+        test_dirs = set()
+
+        # Strategy 1: Check for solution files first as they're usually at the root
+        sln_files = self._find_solution_files(repo)
+        if sln_files:
+            # If we have solution files, analyze them first to get project references
+            sln_projects = self._analyze_solution_files(repo, sln_files)
+            if sln_projects:
+                for project_path in sln_projects[
+                    :max_files
+                ]:  # Limit to avoid rate limiting
+                    try:
+                        content = self._get_file_content(repo, project_path)
+                        if not content:
+                            continue
+
+                        directory = os.path.dirname(project_path)
+
+                        if self.is_test_project_file(content):
+                            test_dirs.add(directory)
+                        else:
+                            # Check directory files for test naming patterns
+                            dir_files = self._list_directory_files(repo, directory)
+                            if self.has_test_file_naming_pattern(dir_files):
+                                test_dirs.add(directory)
+                            else:
+                                source_dirs.add(directory)
+                    except Exception as e:
+                        print(f"Error analyzing project file {project_path}: {e}")
+
+                # If we found both source and test dirs from solution analysis, return results
+                if source_dirs and test_dirs:
+                    return source_dirs, test_dirs
+
+        # Strategy 2: Find all .csproj files if solutions didn't provide enough information
+        csproj_files = self._find_csproj_files(repo)
+
+        # Prioritize csproj files with likely test references first to minimize API calls
+        prioritized_files = []
+        for file_path in csproj_files:
+            priority = 0
+            if "test" in file_path.lower():
+                priority += 2
+            if "src" in file_path.lower():
+                priority -= 1
+            prioritized_files.append((priority, file_path))
+
+        # Sort by priority (higher first)
+        prioritized_files.sort(reverse=True)
+
+        # Process prioritized files up to the max_files limit
+        for _, file_path in prioritized_files[:max_files]:
+            if file_path in sln_projects:  # Skip if already analyzed via solution
+                continue
+
+            try:
+                # Get the content of the .csproj file
+                content = self._get_file_content(repo, file_path)
+                if not content:
+                    continue
+
+                directory = os.path.dirname(file_path)
+
+                # Check if it's a test project
+                if self.is_test_project_file(content):
+                    test_dirs.add(directory)
+                else:
+                    # Check directory files for test naming patterns
+                    dir_files = self._list_directory_files(repo, directory)
+                    if self.has_test_file_naming_pattern(dir_files):
+                        test_dirs.add(directory)
+                    else:
+                        source_dirs.add(directory)
+            except Exception as e:
+                print(f"Error analyzing file {file_path}: {e}")
+
+        # Strategy 3: If we still don't have enough information, analyze workflow files
+        if not test_dirs:
+            workflow_test_dirs = self.analyze_workflow_files(repo_name)
+            test_dirs.update(workflow_test_dirs)
+
+        # Strategy 4: Use conventional directory names as fallback
+        if not source_dirs and not test_dirs:
+            conventional_src_dirs = {"src", "source", "lib", "common", "main"}
+            conventional_test_dirs = {"test", "tests", "unittest", "unittests"}
+
+            try:
+                root_contents = repo.get_contents("")
+                for content in root_contents:
+                    if content.type == "dir":
+                        if content.name.lower() in conventional_src_dirs:
+                            source_dirs.add(content.path)
+                        elif content.name.lower() in conventional_test_dirs:
+                            test_dirs.add(content.path)
+            except Exception as e:
+                print(f"Error analyzing root directories: {e}")
+
+        # Remove test directories from source directories (in case of overlap)
+        source_dirs = source_dirs - test_dirs
+
+        return source_dirs, test_dirs
+
+    def _analyze_solution_files(self, repo, sln_files: List[str]) -> List[str]:
+        """
+        Analyzes .sln files to extract project references.
+
+        Args:
+            repo: The GitHub repository object
+            sln_files: List of .sln file paths
+
+        Returns:
+            List[str]: List of project file paths referenced in the solution
+        """
+        project_paths = []
+
+        for sln_path in sln_files:
+            try:
+                content = self._get_file_content(repo, sln_path)
+                if not content:
+                    continue
+
+                # Extract project references using regex (simplified)
+                # Pattern matches: Project("{GUID}") = "ProjectName", "Path\To\Project.csproj", "{GUID}"
+                pattern = r'Project\([^)]+\)\s*=\s*"[^"]+",\s*"([^"]+)",\s*"[^"]+"'
+                matches = re.findall(pattern, content)
+
+                for match in matches:
+                    if match.endswith(".csproj"):
+                        # Convert Windows paths to Unix paths
+                        match = match.replace("\\", "/")
+                        # Make path absolute relative to solution directory
+                        sln_dir = os.path.dirname(sln_path)
+                        if sln_dir:
+                            project_path = os.path.normpath(
+                                os.path.join(sln_dir, match)
+                            )
+                        else:
+                            project_path = match
+
+                        project_paths.append(project_path)
+            except Exception as e:
+                print(f"Error parsing solution file {sln_path}: {e}")
+
+        return project_paths
+
+    def _find_csproj_files(self, repo) -> List[str]:
+        """
+        Finds all .csproj files in a repository using the GitHub API.
+
+        Args:
+            repo: The GitHub repository object
+
+        Returns:
+            List[str]: List of file paths to .csproj files
+        """
+        result = []
+        try:
+            contents = repo.get_contents("")
+            while contents:
+                file_content = contents.pop(0)
+                if file_content.type == "dir":
+                    contents.extend(repo.get_contents(file_content.path))
+                elif file_content.name.endswith(".csproj"):
+                    result.append(file_content.path)
+        except Exception as e:
+            print(f"Error finding .csproj files: {e}")
+
+        return result
+
+    def _find_solution_files(self, repo) -> List[str]:
+        """
+        Finds all .sln (solution) files in a repository using the GitHub API.
+
+        Args:
+            repo: The GitHub repository object
+
+        Returns:
+            List[str]: List of file paths to .sln files
+        """
+        result = []
+        try:
+            contents = repo.get_contents("")
+            while contents:
+                file_content = contents.pop(0)
+                if file_content.type == "dir":
+                    contents.extend(repo.get_contents(file_content.path))
+                elif file_content.name.endswith(".sln"):
+                    result.append(file_content.path)
+        except Exception as e:
+            print(f"Error finding .sln files: {e}")
+
+        return result
+
+    def _get_file_content(self, repo, file_path: str) -> Optional[str]:
+        """
+        Gets the content of a file from GitHub.
+
+        Args:
+            repo: The GitHub repository object
+            file_path: Path to the file
+
+        Returns:
+            Optional[str]: The file content as string, or None if not found
+        """
+        try:
+            file_content = repo.get_contents(file_path)
+            if hasattr(file_content, "content"):
+                return base64.b64decode(file_content.content).decode("utf-8")
+            return None
+        except Exception as e:
+            print(f"Error getting file content for {file_path}: {e}")
+            return None
+
+    def _list_directory_files(self, repo, directory: str) -> List[str]:
+        """
+        Lists all files in a directory.
+
+        Args:
+            repo: The GitHub repository object
+            directory: Path to the directory
+
+        Returns:
+            List[str]: List of file names in the directory
+        """
+        try:
+            contents = repo.get_contents(directory)
+            return [content.name for content in contents if content.type == "file"]
+        except Exception as e:
+            print(f"Error listing directory {directory}: {e}")
+            return []
+
+    def analyze_workflow_files(self, repo_name: str) -> Set[str]:
+        """
+        Analyzes GitHub workflow files to identify dotnet test commands.
+
+        Args:
+            repo_name: The repository name in format "owner/repo"
+
+        Returns:
+            Set[str]: Set of directories referenced in dotnet test commands
+        """
+        import yaml
+
+        repo = self.github_api.get_repo(repo_name)
+        test_dirs = set()
+
+        try:
+            # Get workflow files from .github/workflows directory
+            workflow_dir = ".github/workflows"
+            workflow_contents = repo.get_contents(workflow_dir)
+
+            for content in workflow_contents:
+                if content.name.endswith((".yml", ".yaml")):
+                    try:
+                        yaml_content = self._get_file_content(repo, content.path)
+                        if not yaml_content:
+                            continue
+
+                        workflow = yaml.safe_load(yaml_content)
+                        if "jobs" not in workflow:
+                            continue
+
+                        # Extract test directories from dotnet test commands
+                        for _, job in workflow["jobs"].items():
+                            if "steps" not in job:
+                                continue
+
+                            for step in job["steps"]:
+                                if "run" not in step:
+                                    continue
+
+                                command = step["run"]
+                                if "dotnet test" in command:
+                                    # Try to extract directory from command
+                                    matches = re.findall(
+                                        r"dotnet test\s+([^\s]+)", command
+                                    )
+                                    for match in matches:
+                                        if match and not match.startswith("-"):
+                                            test_dirs.add(match)
+                    except Exception as e:
+                        print(f"Error parsing workflow file {content.path}: {e}")
+        except Exception as e:
+            print(f"Error accessing workflow files: {e}")
+
+        return test_dirs

--- a/gitbugactions/actions/workflow_factory.py
+++ b/gitbugactions/actions/workflow_factory.py
@@ -12,7 +12,11 @@ from gitbugactions.actions.python.pytest_workflow import PytestWorkflow
 from gitbugactions.actions.python.unittest_workflow import UnittestWorkflow
 from gitbugactions.actions.rust.cargo_workflow import CargoWorkflow
 from gitbugactions.actions.workflow import GitHubWorkflow
+from gitbugactions.actions.csharp.dotnet_workflow import DotNetWorkflow
 from gitbugactions.utils.file_reader import FileReader, RegularFileReader
+
+from typing import Optional
+import yaml
 
 
 class GitHubWorkflowFactory:
@@ -34,6 +38,7 @@ class GitHubWorkflowFactory:
                 "go": GoWorkflow.BUILD_TOOL_KEYWORDS,
                 "npm": NpmWorkflow.BUILD_TOOL_KEYWORDS,
                 "cargo": CargoWorkflow.BUILD_TOOL_KEYWORDS,
+                "dotnet": DotNetWorkflow.BUILD_TOOL_KEYWORDS,
             }
             aggregate_keywords = {kw for _ in build_tool_keywords.values() for kw in _}
             keyword_counts = {keyword: 0 for keyword in aggregate_keywords}
@@ -119,5 +124,7 @@ class GitHubWorkflowFactory:
                 )
             case ("rust", "cargo"):
                 return CargoWorkflow(path, content)
+            case ("c#", "dotnet"):
+                return DotNetWorkflow(path, content)
             case (_, _):
                 return UnknownWorkflow(path, content)

--- a/gitbugactions/collect_bugs/bug_patch.py
+++ b/gitbugactions/collect_bugs/bug_patch.py
@@ -12,7 +12,7 @@ from gitbugactions.actions.actions import ActTestsRun
 from gitbugactions.github_api import GithubAPI
 from gitbugactions.test_executor import TestExecutor
 from gitbugactions.utils.file_utils import get_patch_file_extensions
-from gitbugactions.utils.repo_utils import git_clean
+from gitbugactions.utils.repo_state_manager import RepoStateManager
 
 
 class ChangeType(Enum):
@@ -175,7 +175,8 @@ class BugPatch:
 
     def __set_commit(self, repo_clone: pygit2.Repository, commit: str):
         commit = repo_clone.revparse_single(commit)
-        git_clean(repo_clone)
+        RepoStateManager.clean_untracked_files(repo_clone)
+
         repo_clone.checkout_tree(commit)
         repo_clone.create_tag(
             str(uuid.uuid4()),
@@ -213,6 +214,9 @@ class BugPatch:
         keep_containers: bool = False,
     ) -> Optional[List[ActTestsRun]]:
         executor.reset_repo()
+        # Clean .act-result before testing
+        RepoStateManager.clean_act_result_dir(executor.repo_clone.workdir)
+
         self.__set_commit(executor.repo_clone, self.previous_commit)
         if not self.__apply_non_code_patch(executor.repo_clone):
             return None
@@ -225,6 +229,9 @@ class BugPatch:
         keep_containers: bool = False,
     ) -> Optional[List[ActTestsRun]]:
         executor.reset_repo()
+        # Clean .act-result before testing
+        RepoStateManager.clean_act_result_dir(executor.repo_clone.workdir)
+
         self.__set_commit(executor.repo_clone, self.previous_commit)
         if not self.__apply_non_code_patch(executor.repo_clone):
             return None
@@ -239,6 +246,9 @@ class BugPatch:
         keep_containers: bool = False,
     ) -> Optional[List[ActTestsRun]]:
         executor.reset_repo()
+        # Clean .act-result before testing
+        RepoStateManager.clean_act_result_dir(executor.repo_clone.workdir)
+
         self.__set_commit(executor.repo_clone, self.commit)
         return executor.run_tests(offline=offline, keep_containers=keep_containers)
 

--- a/gitbugactions/docker/export.py
+++ b/gitbugactions/docker/export.py
@@ -224,7 +224,6 @@ def extract_diff(container_id: str, diff_file_path: str, ignore_paths: List[str]
     for change in diff:
         # Check if the path matches any of the ignore patterns
         if any(fnmatch.fnmatch(change["Path"], pattern) for pattern in ignore_paths):
-            print(f"Ignoring {change['Path']} because it matches {ignore_paths}")
             continue
 
         # The index removes the empty string from the beggining (/path...)

--- a/gitbugactions/docker/export.py
+++ b/gitbugactions/docker/export.py
@@ -5,6 +5,7 @@ import shutil
 import tarfile
 import tempfile
 import uuid
+import fnmatch
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -208,9 +209,9 @@ def extract_diff(container_id: str, diff_file_path: str, ignore_paths: List[str]
         container_id (str): Id of the Docker container.
         diff_file_path (str): Path on which the diff file will be saved.
         ignore_paths (List[str], optional): Paths that will not be extracted.
-            For instance, if the '/tmp' folder is on the list, any files
-            changed on this folder or its child folders will not be on the
-            diff file. Defaults to [].
+            Supports glob patterns (e.g., "**/.act-result/"). For instance,
+            if the '/tmp' folder is on the list, any files changed on this
+            folder or its child folders will not be on the diff file. Defaults to [].
     """
     save_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid4()))
     client = DockerClient.getInstance()
@@ -221,7 +222,9 @@ def extract_diff(container_id: str, diff_file_path: str, ignore_paths: List[str]
 
     # Create diff tree
     for change in diff:
-        if any(map(lambda path: change["Path"].startswith(path), ignore_paths)):
+        # Check if the path matches any of the ignore patterns
+        if any(fnmatch.fnmatch(change["Path"], pattern) for pattern in ignore_paths):
+            print(f"Ignoring {change['Path']} because it matches {ignore_paths}")
             continue
 
         # The index removes the empty string from the beggining (/path...)

--- a/gitbugactions/test_executor.py
+++ b/gitbugactions/test_executor.py
@@ -90,7 +90,6 @@ class TestExecutor:
         keep_containers: bool = False,
         offline: bool = False,
         timeout: int = 10,
-        github_api=None,
     ) -> List[ActTestsRun]:
         act_runs: List[ActTestsRun] = []
         default_actions = False
@@ -102,7 +101,6 @@ class TestExecutor:
             runner_image=self.runner_image,
             offline=offline,
             base_image=self.base_image,
-            github_api=github_api,
         )
         if len(test_actions.test_workflows) == 0 and self.default_actions is not None:
             default_actions = True

--- a/gitbugactions/test_executor.py
+++ b/gitbugactions/test_executor.py
@@ -86,7 +86,11 @@ class TestExecutor:
         )
 
     def run_tests(
-        self, keep_containers: bool = False, offline: bool = False, timeout: int = 10
+        self,
+        keep_containers: bool = False,
+        offline: bool = False,
+        timeout: int = 10,
+        github_api=None,
     ) -> List[ActTestsRun]:
         act_runs: List[ActTestsRun] = []
         default_actions = False
@@ -98,6 +102,7 @@ class TestExecutor:
             runner_image=self.runner_image,
             offline=offline,
             base_image=self.base_image,
+            github_api=github_api,
         )
         if len(test_actions.test_workflows) == 0 and self.default_actions is not None:
             default_actions = True

--- a/gitbugactions/utils/actions_utils.py
+++ b/gitbugactions/utils/actions_utils.py
@@ -40,7 +40,7 @@ def get_default_github_actions(
                 capture_output=True,
             )
             try:
-                actions = GitHubActions(repo_clone.workdir, language, github_api=None)
+                actions = GitHubActions(repo_clone.workdir, language)
                 if len(actions.test_workflows) == 1:
                     executor = TestExecutor(
                         repo_clone, language, act_cache_dir, actions

--- a/gitbugactions/utils/actions_utils.py
+++ b/gitbugactions/utils/actions_utils.py
@@ -10,6 +10,7 @@ import yaml
 
 from gitbugactions.actions.actions import ActCacheDirManager, GitHubActions
 from gitbugactions.test_executor import TestExecutor
+from gitbugactions.github_api import GithubAPI
 
 
 def get_default_github_actions(
@@ -39,7 +40,7 @@ def get_default_github_actions(
                 capture_output=True,
             )
             try:
-                actions = GitHubActions(repo_clone.workdir, language)
+                actions = GitHubActions(repo_clone.workdir, language, github_api=None)
                 if len(actions.test_workflows) == 1:
                     executor = TestExecutor(
                         repo_clone, language, act_cache_dir, actions

--- a/gitbugactions/utils/file_utils.py
+++ b/gitbugactions/utils/file_utils.py
@@ -31,10 +31,11 @@ def get_file_type(language: str, file_path: str) -> FileType:
         "javascript": {"js", "cjs", "mjs", "jsx"},
         "rust": {"rs"},
         "typescript": {"ts", "tsx"},
+        "c#": {"cs"},
     }
-    test_keywords = {"test", "tests", "__tests__"}
+    test_keywords = {"test", "tests", "__tests__", "Test", "Tests"}
 
-    if language in ["java", "python", "javascript", "rust", "typescript"]:
+    if language in ["java", "python", "javascript", "rust", "typescript", "c#"]:
         if any([keyword in file_path.split(os.sep) for keyword in test_keywords]):
             return FileType.TESTS
     if language in ["go"]:

--- a/gitbugactions/utils/repo_state_manager.py
+++ b/gitbugactions/utils/repo_state_manager.py
@@ -1,0 +1,56 @@
+import os
+import shutil
+import subprocess
+import logging
+from typing import Optional
+
+import pygit2
+
+
+class RepoStateManager:
+    @staticmethod
+    def clean_untracked_files(repo: pygit2.Repository):
+        """
+        Clean untracked files using git clean.
+
+        This removes all untracked files and directories, including .act-result.
+        The -f flag forces removal, -d includes directories, and -x ignores .gitignore rules.
+        """
+        subprocess.run(
+            ["git", "clean", "-f", "-d", "-x"],
+            cwd=repo.workdir,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def clean_act_result_dir(repo_workdir: str):
+        """
+        Remove .act-result directory if it exists.
+
+        Note: This is only needed when you want to clean just the .act-result directory
+        without cleaning all untracked files. If you're already calling clean_untracked_files
+        or reset_to_commit, this method is redundant.
+        """
+        act_result_path = os.path.join(repo_workdir, ".act-result")
+        if os.path.exists(act_result_path):
+            try:
+                shutil.rmtree(act_result_path)
+            except Exception as e:
+                logging.error(f"Error removing .act-result directory: {e}")
+
+    @staticmethod
+    def reset_to_commit(
+        repo: pygit2.Repository, commit_id: Optional[pygit2.Oid] = None
+    ):
+        """
+        Reset repository to a specific commit (if provided) and clean untracked files.
+
+        This is a comprehensive cleanup method that:
+        1. Resets to the specified commit if commit_id is provided
+        2. Cleans all untracked files and directories, including .act-result
+        """
+        if commit_id:
+            repo.reset(commit_id, pygit2.GIT_RESET_HARD)
+
+        # Always clean untracked files
+        RepoStateManager.clean_untracked_files(repo)

--- a/run_bug.py
+++ b/run_bug.py
@@ -14,6 +14,7 @@ from gitbugactions.actions.workflow_factory import GitHubWorkflowFactory
 from gitbugactions.docker.client import DockerClient
 from gitbugactions.docker.export import create_diff_image
 from gitbugactions.test_executor import TestExecutor
+from gitbugactions.github_api import GithubAPI
 
 
 def get_bug_from_metadata(metadata_path, repo_name, commit):
@@ -44,7 +45,7 @@ def get_default_actions(diff_folder_path, repo_clone, language) -> GitHubActions
 
     workflows = [GitHubWorkflowFactory.create_workflow(new_workflow_path, language)]
 
-    default_actions = GitHubActions(repo_clone.workdir, language)
+    default_actions = GitHubActions(repo_clone.workdir, language, github_api=None)
     default_actions.test_workflows = workflows
     os.remove(new_workflow_path)
 

--- a/run_bug.py
+++ b/run_bug.py
@@ -14,7 +14,6 @@ from gitbugactions.actions.workflow_factory import GitHubWorkflowFactory
 from gitbugactions.docker.client import DockerClient
 from gitbugactions.docker.export import create_diff_image
 from gitbugactions.test_executor import TestExecutor
-from gitbugactions.github_api import GithubAPI
 
 
 def get_bug_from_metadata(metadata_path, repo_name, commit):
@@ -45,7 +44,7 @@ def get_default_actions(diff_folder_path, repo_clone, language) -> GitHubActions
 
     workflows = [GitHubWorkflowFactory.create_workflow(new_workflow_path, language)]
 
-    default_actions = GitHubActions(repo_clone.workdir, language, github_api=None)
+    default_actions = GitHubActions(repo_clone.workdir, language)
     default_actions.test_workflows = workflows
     os.remove(new_workflow_path)
 

--- a/test/actions/test_dotnet_project_analyzer.py
+++ b/test/actions/test_dotnet_project_analyzer.py
@@ -1,0 +1,278 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from gitbugactions.actions.csharp.helpers.dotnet_project_analyzer import (
+    DotNetProjectAnalyzer,
+)
+
+
+@pytest.fixture
+def github_api():
+    return MagicMock()
+
+
+@pytest.fixture
+def analyzer(github_api):
+    return DotNetProjectAnalyzer(github_api)
+
+
+def test_is_test_project_file_with_framework_reference(analyzer):
+    # Sample .csproj content with test framework reference
+    content = """
+    <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+            <TargetFramework>net6.0</TargetFramework>
+        </PropertyGroup>
+        <ItemGroup>
+            <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+            <PackageReference Include="xunit" Version="2.4.1" />
+            <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+        </ItemGroup>
+    </Project>
+    """
+    assert analyzer.is_test_project_file(content)
+
+
+def test_is_test_project_file_with_property(analyzer):
+    # Sample .csproj content with IsTestProject property
+    content = """
+    <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+            <TargetFramework>net6.0</TargetFramework>
+            <IsTestProject>true</IsTestProject>
+        </PropertyGroup>
+    </Project>
+    """
+    assert analyzer.is_test_project_file(content)
+
+
+def test_is_test_project_file_not_test(analyzer):
+    # Sample .csproj content without test indicators
+    content = """
+    <Project Sdk="Microsoft.NET.Sdk">
+        <PropertyGroup>
+            <TargetFramework>net6.0</TargetFramework>
+            <OutputType>Library</OutputType>
+        </PropertyGroup>
+        <ItemGroup>
+            <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        </ItemGroup>
+    </Project>
+    """
+    assert not analyzer.is_test_project_file(content)
+
+
+def test_has_test_file_naming_pattern(analyzer):
+    # Test with various file names
+    files = [
+        "CalculatorTest.cs",
+        "UserControllerTests.cs",
+        "test_helpers.cs",
+        "Calculator.cs",
+    ]
+    assert analyzer.has_test_file_naming_pattern(files)
+
+
+def test_has_test_file_naming_pattern_no_match(analyzer):
+    # Test with non-test file names
+    files = ["Calculator.cs", "UserController.cs", "Program.cs"]
+    assert not analyzer.has_test_file_naming_pattern(files)
+
+
+@patch.object(DotNetProjectAnalyzer, "_find_csproj_files")
+@patch.object(DotNetProjectAnalyzer, "_get_file_content")
+@patch.object(DotNetProjectAnalyzer, "_list_directory_files")
+def test_analyze_repository(
+    mock_list_files, mock_get_content, mock_find_csproj, analyzer, github_api
+):
+    # Mock the GitHub API and repository
+    repo = MagicMock()
+    github_api.get_repo.return_value = repo
+
+    # Mock finding .csproj files
+    mock_find_csproj.return_value = [
+        "src/App/App.csproj",
+        "src/Core/Core.csproj",
+        "tests/UnitTests/UnitTests.csproj",
+    ]
+
+    # Mock file contents
+    def mock_get_content_side_effect(repo, path):
+        if path == "src/App/App.csproj" or path == "src/Core/Core.csproj":
+            return """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>
+            </Project>
+            """
+        elif path == "tests/UnitTests/UnitTests.csproj":
+            return """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+                    <PackageReference Include="xunit" Version="2.4.1" />
+                </ItemGroup>
+            </Project>
+            """
+        return None
+
+    mock_get_content.side_effect = mock_get_content_side_effect
+
+    # Mock directory listings
+    mock_list_files.return_value = ["Program.cs", "Controller.cs"]
+
+    # Test repository analysis
+    source_dirs, test_dirs = analyzer.analyze_repository("owner/repo")
+
+    # Verify results
+    assert source_dirs == {"src/App", "src/Core"}
+    assert test_dirs == {"tests/UnitTests"}
+
+
+@patch.object(DotNetProjectAnalyzer, "_find_solution_files")
+@patch.object(DotNetProjectAnalyzer, "_analyze_solution_files")
+@patch.object(DotNetProjectAnalyzer, "_get_file_content")
+@patch.object(DotNetProjectAnalyzer, "_list_directory_files")
+def test_analyze_repository_with_solution(
+    mock_list_files,
+    mock_get_content,
+    mock_analyze_solution,
+    mock_find_solution,
+    analyzer,
+    github_api,
+):
+    # Mock the GitHub API and repository
+    repo = MagicMock()
+    github_api.get_repo.return_value = repo
+
+    # Mock finding solution files
+    mock_find_solution.return_value = ["MySolution.sln"]
+
+    # Mock solution analysis
+    mock_analyze_solution.return_value = [
+        "src/App/App.csproj",
+        "src/Core/Core.csproj",
+        "tests/UnitTests/UnitTests.csproj",
+    ]
+
+    # Mock file contents
+    def mock_get_content_side_effect(repo, path):
+        if path == "src/App/App.csproj" or path == "src/Core/Core.csproj":
+            return """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>
+            </Project>
+            """
+        elif path == "tests/UnitTests/UnitTests.csproj":
+            return """
+            <Project Sdk="Microsoft.NET.Sdk">
+                <PropertyGroup>
+                    <TargetFramework>net6.0</TargetFramework>
+                </PropertyGroup>
+                <ItemGroup>
+                    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+                    <PackageReference Include="xunit" Version="2.4.1" />
+                </ItemGroup>
+            </Project>
+            """
+        return None
+
+    mock_get_content.side_effect = mock_get_content_side_effect
+
+    # Mock directory listings
+    mock_list_files.return_value = ["Program.cs", "Controller.cs"]
+
+    # Test repository analysis
+    source_dirs, test_dirs = analyzer.analyze_repository("owner/repo")
+
+    # Verify results
+    assert source_dirs == {"src/App", "src/Core"}
+    assert test_dirs == {"tests/UnitTests"}
+
+
+def test_analyze_solution_files(analyzer):
+    # Mock the repository
+    repo = MagicMock()
+
+    # Create a mock solution file content
+    solution_content = """
+    Microsoft Visual Studio Solution File, Format Version 12.00
+    # Visual Studio Version 17
+    VisualStudioVersion = 17.0.31903.59
+    MinimumVisualStudioVersion = 10.0.40219.1
+    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "src\\App\\App.csproj", "{8AC9E0E8-E84D-4A7F-B15D-7497AEA5E5C9}"
+    EndProject
+    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "src\\Core\\Core.csproj", "{3C4A1FC7-D9C3-4A7F-B15D-7497AEA5E5C9}"
+    EndProject
+    Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "tests\\UnitTests\\UnitTests.csproj", "{7F1D64B7-D9C3-4A7F-B15D-7497AEA5E5C9}"
+    EndProject
+    Global
+        GlobalSection(SolutionConfigurationPlatforms) = preSolution
+            Debug|Any CPU = Debug|Any CPU
+            Release|Any CPU = Release|Any CPU
+        EndGlobalSection
+    EndGlobal
+    """
+
+    # Mock getting file content
+    analyzer._get_file_content = MagicMock(return_value=solution_content)
+
+    # Test solution file analysis
+    result = analyzer._analyze_solution_files(repo, ["MySolution.sln"])
+
+    # Verify results - should have 3 project paths extracted
+    expected_paths = [
+        "src/App/App.csproj",
+        "src/Core/Core.csproj",
+        "tests/UnitTests/UnitTests.csproj",
+    ]
+    for expected_path in expected_paths:
+        assert expected_path in result
+
+    # Should have found all 3 projects
+    assert len(result) == 3
+
+
+@patch.object(DotNetProjectAnalyzer, "_get_file_content")
+def test_analyze_workflow_files(mock_get_content, analyzer, github_api):
+    # Mock the GitHub API and repository
+    repo = MagicMock()
+    github_api.get_repo.return_value = repo
+
+    # Mock workflow directory contents
+    workflow_content = MagicMock()
+    workflow_content.name = "ci.yml"
+    workflow_content.path = ".github/workflows/ci.yml"
+    repo.get_contents.return_value = [workflow_content]
+
+    # Mock workflow file content
+    workflow_yml = """
+    name: CI
+    on: [push, pull_request]
+    jobs:
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v2
+          - name: Setup .NET
+            uses: actions/setup-dotnet@v1
+            with:
+              dotnet-version: 6.0.x
+          - name: Build
+            run: dotnet build
+          - name: Test
+            run: dotnet test tests/UnitTests
+    """
+    mock_get_content.return_value = workflow_yml
+
+    # Test workflow analysis
+    test_dirs = analyzer.analyze_workflow_files("owner/repo")
+
+    # Verify results
+    assert test_dirs == {"tests/UnitTests"}

--- a/test/actions/test_dotnet_workflow.py
+++ b/test/actions/test_dotnet_workflow.py
@@ -67,7 +67,7 @@ class TestDotNetWorkflow(unittest.TestCase):
         test_step = self.workflow.doc["jobs"]["build"]["steps"][4]
         self.assertIn("JUnitXml.TestLogger", test_step["run"])
         self.assertIn(
-            '--logger:"junit;LogFilePath=./TestResults/test-results.xml"',
+            '--logger:"junit;LogFilePath=TestResults/test-results.xml"',
             test_step["run"],
         )
 

--- a/test/actions/test_dotnet_workflow.py
+++ b/test/actions/test_dotnet_workflow.py
@@ -1,0 +1,157 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import yaml
+
+from gitbugactions.actions.csharp.dotnet_workflow import DotNetWorkflow
+from gitbugactions.actions.csharp.helpers import DotNetProjectAnalyzer
+
+
+class TestDotNetWorkflow(unittest.TestCase):
+    def setUp(self):
+        # Sample workflow YAML
+        workflow_yaml = """
+        name: .NET Build and Test
+        
+        on:
+          push:
+            branches: [ main ]
+          pull_request:
+            branches: [ main ]
+            
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+            - uses: actions/checkout@v2
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v1
+              with:
+                dotnet-version: 6.0.x
+            - name: Restore dependencies
+              run: dotnet restore
+            - name: Build
+              run: dotnet build --no-restore
+            - name: Test
+              run: dotnet test --no-build
+        """
+
+        # Parse YAML to dict
+        workflow_dict = yaml.safe_load(workflow_yaml)
+
+        # Create DotNetWorkflow instance
+        self.workflow = DotNetWorkflow("owner/repo")
+        self.workflow.doc = workflow_dict  # Set the workflow document directly
+
+    def test_is_test_command(self):
+        # Test various commands to check if they are recognized as test commands
+        self.assertTrue(self.workflow._is_test_command("dotnet test"))
+        self.assertTrue(self.workflow._is_test_command("dotnet test --no-build"))
+        self.assertTrue(
+            self.workflow._is_test_command("dotnet test ./tests/MyProject.Tests")
+        )
+        self.assertFalse(self.workflow._is_test_command("dotnet build"))
+        self.assertFalse(self.workflow._is_test_command("dotnet restore"))
+
+    @patch.object(DotNetProjectAnalyzer, "analyze_repository")
+    def test_instrument_test_steps(self, mock_analyze_repo):
+        # Mock the project analysis
+        mock_analyze_repo.return_value = ({"src"}, {"test"})
+
+        # Mock GitHub API
+        github_api = MagicMock()
+
+        # Instrument the test steps with GitHub API
+        self.workflow.instrument_test_steps(github_api)
+
+        # Check if test command was properly instrumented
+        test_step = self.workflow.doc["jobs"]["build"]["steps"][4]
+        self.assertIn("JUnitXml.TestLogger", test_step["run"])
+        self.assertIn(
+            '--logger:"junit;LogFilePath=./TestResults/test-results.xml"',
+            test_step["run"],
+        )
+
+    @patch.object(DotNetProjectAnalyzer, "analyze_repository")
+    def test_get_project_structure(self, mock_analyze_repo):
+        # Mock the project analysis
+        mock_analyze_repo.return_value = ({"src/App", "src/Core"}, {"tests/UnitTests"})
+
+        # Mock GitHub API
+        github_api = MagicMock()
+
+        # Get project structure
+        source_dirs, test_dirs = self.workflow.get_project_structure(github_api)
+
+        # Verify results
+        self.assertEqual(source_dirs, {"src/App", "src/Core"})
+        self.assertEqual(test_dirs, {"tests/UnitTests"})
+
+        # Verify analyzer was created and used
+        self.assertIsNotNone(self.workflow.analyzer)
+        mock_analyze_repo.assert_called_once_with("owner/repo")
+
+    @patch.object(DotNetProjectAnalyzer, "analyze_repository")
+    def test_get_project_structure_cached(self, mock_analyze_repo):
+        # Set cached values
+        self.workflow.source_dirs = {"src/App"}
+        self.workflow.test_dirs = {"tests/UnitTests"}
+
+        # Mock GitHub API
+        github_api = MagicMock()
+
+        # Get project structure
+        source_dirs, test_dirs = self.workflow.get_project_structure(github_api)
+
+        # Verify cached results are returned
+        self.assertEqual(source_dirs, {"src/App"})
+        self.assertEqual(test_dirs, {"tests/UnitTests"})
+
+        # Verify analyzer was not called
+        mock_analyze_repo.assert_not_called()
+
+    @patch.object(DotNetProjectAnalyzer, "analyze_repository")
+    def test_get_project_structure_error(self, mock_analyze_repo):
+        # Mock the project analysis to raise an exception
+        mock_analyze_repo.side_effect = Exception("API error")
+
+        # Mock GitHub API
+        github_api = MagicMock()
+
+        # Get project structure
+        source_dirs, test_dirs = self.workflow.get_project_structure(github_api)
+
+        # Verify default values are returned on error
+        self.assertEqual(source_dirs, {"src", "."})
+        self.assertEqual(test_dirs, {"test", "tests"})
+
+    @patch.object(DotNetWorkflow, "get_project_structure")
+    def test_get_source_directories(self, mock_get_structure):
+        # Mock the project structure
+        mock_get_structure.return_value = ({"src/App", "src/Core"}, {"tests/UnitTests"})
+
+        # Mock GitHub API
+        github_api = MagicMock()
+
+        # Get source directories
+        source_dirs = self.workflow.get_source_directories(github_api)
+
+        # Verify results
+        self.assertEqual(source_dirs, {"src/App", "src/Core"})
+
+    @patch.object(DotNetWorkflow, "get_project_structure")
+    def test_get_test_directories(self, mock_get_structure):
+        # Mock the project structure
+        mock_get_structure.return_value = ({"src/App", "src/Core"}, {"tests/UnitTests"})
+
+        # Mock GitHub API
+        github_api = MagicMock()
+
+        # Get test directories
+        test_dirs = self.workflow.get_test_directories(github_api)
+
+        # Verify results
+        self.assertEqual(test_dirs, {"tests/UnitTests"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/actions/test_dotnet_workflow.py
+++ b/test/actions/test_dotnet_workflow.py
@@ -88,7 +88,7 @@ class TestDotNetWorkflow(unittest.TestCase):
 
         # Verify analyzer was created and used
         self.assertIsNotNone(self.workflow.analyzer)
-        mock_analyze_repo.assert_called_once_with("owner/repo")
+        mock_analyze_repo.assert_called_once()
 
     @patch.object(DotNetProjectAnalyzer, "analyze_repository")
     def test_get_project_structure_cached(self, mock_analyze_repo):

--- a/test/actions/test_workflow.py
+++ b/test/actions/test_workflow.py
@@ -288,7 +288,7 @@ def test_rust(yml_file):
 
 @pytest.mark.parametrize(
     "yml_file",
-    [("test/resources/test_workflows/dotnet/tests.yml")],
+    ["test/resources/test_workflows/dotnet/tests.yml"],
 )
 def test_dotnet(yml_file):
     """Test the workflow factory for dotnet workflows."""

--- a/test/actions/test_workflow.py
+++ b/test/actions/test_workflow.py
@@ -9,7 +9,9 @@ from gitbugactions.actions.npm.npm_mocha_workflow import NpmMochaWorkflow
 from gitbugactions.actions.npm.npm_vitest_workflow import NpmVitestWorkflow
 from gitbugactions.actions.python.pytest_workflow import PytestWorkflow
 from gitbugactions.actions.rust.cargo_workflow import CargoWorkflow
+from gitbugactions.actions.csharp.dotnet_workflow import DotNetWorkflow
 from gitbugactions.actions.workflow_factory import GitHubWorkflowFactory
+
 from gitbugactions.github_api import GithubToken
 
 
@@ -282,3 +284,13 @@ def test_rust(yml_file):
     """Test the workflow factory for rust workflows."""
     workflow = create_workflow(yml_file, "rust")
     assert isinstance(workflow, CargoWorkflow)
+
+
+@pytest.mark.parametrize(
+    "yml_file",
+    [("test/resources/test_workflows/dotnet/tests.yml")],
+)
+def test_dotnet(yml_file):
+    """Test the workflow factory for dotnet workflows."""
+    workflow = create_workflow(yml_file, "c#")
+    assert isinstance(workflow, DotNetWorkflow)

--- a/test/integration_tests/test_collect_bugs.py
+++ b/test/integration_tests/test_collect_bugs.py
@@ -1110,6 +1110,27 @@ class TestCollectBugs:
                 ]
                 assert data["strategy"] == "FAIL_PASS"
 
+    @pytest.mark.dependency()
+    def test_gitbugactions_dotnet_test_repo(self):
+        """
+        Verifies that the dotnet project bugs have been found
+
+        repo: https://github.com/gitbugactions/gitbugactions-dotnet-test-repo
+        """
+        with open(
+            "test/resources/test_collect_bugs_out/gitbugactions-gitbugactions-dotnet-test-repo.json",
+            "r",
+        ) as f:
+            lines = f.readlines()
+            assert len(lines) == 1
+
+            for line in lines:
+                data = json.loads(line)
+                assert data["commit_hash"] in [
+                    "65b86c6855427d96067519b75a7bd41b093a2b2f",
+                ]
+                assert data["strategy"] == "FAIL_PASS"
+
     def test_collected_data(self):
         with open(
             "test/resources/test_collect_bugs_out/data.json",
@@ -1117,7 +1138,7 @@ class TestCollectBugs:
         ) as f:
             data = json.load(f)
             assert len(data.keys()) == 10
-            assert data["gitbugactions/gitbugactions-maven-test-repo"]["commits"] == 12
+            assert data["gitbugactions/gitbugactions-maven-test-repo"]["commits"] == 13
             assert data["gitbugactions/gitbugactions-pytest-test-repo"]["commits"] == 6
             assert data["gitbugactions/gitbugactions-gradle-test-repo"]["commits"] == 2
             assert (
@@ -1138,6 +1159,7 @@ class TestCollectBugs:
                 data["gitbugactions/gitbugactions-ts-npm-jest-test-repo"]["commits"]
                 == 2
             )
+            assert data["gitbugactions/gitbugactions-dotnet-test-repo"]["commits"] == 2
             assert (
                 data["gitbugactions/gitbugactions-maven-test-repo"][
                     "possible_bug_patches"
@@ -1192,6 +1214,12 @@ class TestCollectBugs:
             )
             assert (
                 data["gitbugactions/gitbugactions-ts-npm-jest-test-repo"][
+                    "possible_bug_patches"
+                ]
+                == 1
+            )
+            assert (
+                data["gitbugactions/gitbugactions-dotnet-test-repo"][
                     "possible_bug_patches"
                 ]
                 == 1

--- a/test/integration_tests/test_collect_repos.py
+++ b/test/integration_tests/test_collect_repos.py
@@ -16,7 +16,8 @@ class BaseCollectReposTest:
     @classmethod
     def teardown_class(cls):
         if os.path.exists(cls.temp_folder):
-            shutil.rmtree(cls.temp_folder)
+            # shutil.rmtree(cls.temp_folder)
+            pass
 
 
 class TestCollectReposInfra(BaseCollectReposTest):
@@ -76,6 +77,8 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 1
+            assert data["actions_run"]["tests"] is not None
+            assert len(data["actions_run"]["tests"]) > 0
 
     def test_collect_repos_npm_mocha(self):
         api = GithubAPI()
@@ -95,6 +98,8 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 1
+            assert data["actions_run"]["tests"] is not None
+            assert len(data["actions_run"]["tests"]) > 0
 
     def test_collect_repos_npm_vitest(self):
         api = GithubAPI()
@@ -114,6 +119,8 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 1
+            assert data["actions_run"]["tests"] is not None
+            assert len(data["actions_run"]["tests"]) > 0
 
     def test_collect_repos_rust(self):
         api = GithubAPI()
@@ -133,6 +140,8 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 1
+            assert data["actions_run"]["tests"] is not None
+            assert len(data["actions_run"]["tests"]) > 0
 
     def test_collect_repos_typescript_jest(self):
         api = GithubAPI()
@@ -152,6 +161,8 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 1
+            assert data["actions_run"]["tests"] is not None
+            assert len(data["actions_run"]["tests"]) > 0
 
     @pytest.mark.skip(
         reason="Skipped due to long runtime and possible changes in repo."
@@ -174,6 +185,8 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 5
+            assert data["actions_run"]["tests"] is not None
+            assert len(data["actions_run"]["tests"]) > 0
 
 
 class TestCollectReposCSharp(BaseCollectReposTest):
@@ -196,3 +209,5 @@ class TestCollectReposCSharp(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 1
+            assert data["actions_run"]["tests"] is not None
+            assert len(data["actions_run"]["tests"]) > 0

--- a/test/integration_tests/test_collect_repos.py
+++ b/test/integration_tests/test_collect_repos.py
@@ -15,9 +15,8 @@ class BaseCollectReposTest:
 
     @classmethod
     def teardown_class(cls):
-        # if os.path.exists(cls.temp_folder):
-        #     shutil.rmtree(cls.temp_folder)
-        assert not os.path.exists(cls.temp_folder)
+        if os.path.exists(cls.temp_folder):
+            shutil.rmtree(cls.temp_folder)
 
 
 class TestCollectReposInfra(BaseCollectReposTest):
@@ -143,27 +142,6 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
         data_file = os.path.join(
             self.temp_folder,
             "gitbugactions-gitbugactions-ts-npm-jest-test-repo.json",
-            "gitbugactions-gitbugactions-dotnet-test-repo.json",
-        )
-
-        assert os.path.exists(data_file)
-        with open(data_file, "r") as f:
-            data = json.load(f)
-            assert "number_of_test_actions" in data
-            assert data["number_of_test_actions"] == 1
-            assert "actions_successful" in data
-            assert data["actions_successful"]
-            assert data["number_of_actions"] == 1
-
-    def test_collect_repos_dotnet(self):
-        api = GithubAPI()
-        repo = api.get_repo("gitbugactions/gitbugactions-dotnet-test-repo")
-
-        CollectReposStrategy(self.temp_folder).handle_repo(repo)
-        data_file = os.path.join(
-            self.temp_folder,
-            "gitbugactions-gitbugactions-ts-npm-jest-test-repo.json",
-            "gitbugactions-gitbugactions-dotnet-test-repo.json",
         )
 
         assert os.path.exists(data_file)
@@ -196,3 +174,25 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
             assert "actions_successful" in data
             assert data["actions_successful"]
             assert data["number_of_actions"] == 5
+
+
+class TestCollectReposCSharp(BaseCollectReposTest):
+
+    def test_collect_repos_dotnet(self):
+        api = GithubAPI()
+        repo = api.get_repo("gitbugactions/gitbugactions-dotnet-test-repo")
+
+        CollectReposStrategy(self.temp_folder).handle_repo(repo)
+        data_file = os.path.join(
+            self.temp_folder,
+            "gitbugactions-gitbugactions-dotnet-test-repo.json",
+        )
+
+        assert os.path.exists(data_file)
+        with open(data_file, "r") as f:
+            data = json.load(f)
+            assert "number_of_test_actions" in data
+            assert data["number_of_test_actions"] == 1
+            assert "actions_successful" in data
+            assert data["actions_successful"]
+            assert data["number_of_actions"] == 1

--- a/test/integration_tests/test_collect_repos.py
+++ b/test/integration_tests/test_collect_repos.py
@@ -15,8 +15,8 @@ class BaseCollectReposTest:
 
     @classmethod
     def teardown_class(cls):
-        if os.path.exists(cls.temp_folder):
-            shutil.rmtree(cls.temp_folder)
+        # if os.path.exists(cls.temp_folder):
+        #     shutil.rmtree(cls.temp_folder)
         assert not os.path.exists(cls.temp_folder)
 
 
@@ -143,6 +143,27 @@ class TestCollectReposJavaScript(BaseCollectReposTest):
         data_file = os.path.join(
             self.temp_folder,
             "gitbugactions-gitbugactions-ts-npm-jest-test-repo.json",
+            "gitbugactions-gitbugactions-dotnet-test-repo.json",
+        )
+
+        assert os.path.exists(data_file)
+        with open(data_file, "r") as f:
+            data = json.load(f)
+            assert "number_of_test_actions" in data
+            assert data["number_of_test_actions"] == 1
+            assert "actions_successful" in data
+            assert data["actions_successful"]
+            assert data["number_of_actions"] == 1
+
+    def test_collect_repos_dotnet(self):
+        api = GithubAPI()
+        repo = api.get_repo("gitbugactions/gitbugactions-dotnet-test-repo")
+
+        CollectReposStrategy(self.temp_folder).handle_repo(repo)
+        data_file = os.path.join(
+            self.temp_folder,
+            "gitbugactions-gitbugactions-ts-npm-jest-test-repo.json",
+            "gitbugactions-gitbugactions-dotnet-test-repo.json",
         )
 
         assert os.path.exists(data_file)

--- a/test/resources/test_collect_bugs/gitbugactions-gitbugactions-dotnet-test-repo.json
+++ b/test/resources/test_collect_bugs/gitbugactions-gitbugactions-dotnet-test-repo.json
@@ -1,0 +1,104 @@
+{
+    "repository": "gitbugactions/gitbugactions-dotnet-test-repo",
+    "stars": 0,
+    "language": "c#",
+    "size": 2,
+    "clone_url": "https://github.com/gitbugactions/gitbugactions-dotnet-test-repo.git",
+    "timestamp": "2025-03-11T14:10:21.163268+00:00Z",
+    "clone_success": true,
+    "number_of_actions": 1,
+    "number_of_test_actions": 1,
+    "actions_successful": true,
+    "actions_build_tools": [
+        "dotnet"
+    ],
+    "actions_test_build_tools": [
+        "dotnet"
+    ],
+    "actions_run": {
+        "failed": false,
+        "tests": [
+            {
+                "classname": "GitBugActions.Tests.AppMathTests",
+                "name": "TestSumTwice",
+                "time": 0.0033318,
+                "results": [
+                    {
+                        "result": "Passed",
+                        "message": "",
+                        "type": ""
+                    }
+                ],
+                "stdout": null,
+                "stderr": null
+            },
+            {
+                "classname": "GitBugActions.Tests.AppMathTests",
+                "name": "TestSum",
+                "time": 0.0001171,
+                "results": [
+                    {
+                        "result": "Passed",
+                        "message": "",
+                        "type": ""
+                    }
+                ],
+                "stdout": null,
+                "stderr": null
+            },
+            {
+                "classname": "GitBugActions.Tests.AppMathTests",
+                "name": "TestMultiply",
+                "time": 5.98e-05,
+                "results": [
+                    {
+                        "result": "Passed",
+                        "message": "",
+                        "type": ""
+                    }
+                ],
+                "stdout": null,
+                "stderr": null
+            },
+            {
+                "classname": "GitBugActions.Tests.AppMathTests",
+                "name": "TestSubtract",
+                "time": 5.53e-05,
+                "results": [
+                    {
+                        "result": "Passed",
+                        "message": "",
+                        "type": ""
+                    }
+                ],
+                "stdout": null,
+                "stderr": null
+            },
+            {
+                "classname": "GitBugActions.Tests.AppMathTests",
+                "name": "TestSubtractTwice",
+                "time": 7.77e-05,
+                "results": [
+                    {
+                        "result": "Passed",
+                        "message": "",
+                        "type": ""
+                    }
+                ],
+                "stdout": null,
+                "stderr": null
+            }
+        ],
+        "stdout": "[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \ud83d\ude80  Start image=gitbugactions:latest\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker pull image=gitbugactions:latest platform= username= forcePull=false\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker create image=gitbugactions:latest platform= entrypoint=[\"tail\" \"-f\" \"/dev/null\"] cmd=[] network=\"host\"\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker run image=gitbugactions:latest platform= entrypoint=[\"tail\" \"-f\" \"/dev/null\"] cmd=[] network=\"host\"\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[chown -R 1000:1000 /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo] user=0 workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \u2b50 Run Main actions/checkout@v3\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker cp src=/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/. dst=/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[chown -R 1000:1000 /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo] user=0 workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2705  Success - Main actions/checkout@v3\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \u2b50 Run Main Setup .NET\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker cp src=/tmp/act-cache/default/act/actions-setup-dotnet@v3/ dst=/var/run/act/actions/actions-setup-dotnet@v3/\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[chown -R 1000:1000 /var/run/act/actions/actions-setup-dotnet@v3/] user=0 workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[node /var/run/act/actions/actions-setup-dotnet@v3/dist/setup/index.js] user= workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | [command]/run/act/actions/actions-setup-dotnet@v3/externals/install-dotnet.sh --channel 9.0\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Attempting to download using aka.ms link https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-x64.tar.gz\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Remote file https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-x64.tar.gz size is 216232002 bytes.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Extracting archive from https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.200/dotnet-sdk-9.0.200-linux-x64.tar.gz\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Downloaded file size is 216232002 bytes.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: The remote and local file sizes are equal.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Installed version is 9.0.200\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Adding to current process PATH: `/usr/share/dotnet`. Note: This change will be visible only when sourcing script.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Note that the script does not resolve dependencies during installation.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: To check the list of dependencies, go to https://learn.microsoft.com/dotnet/core/install, select your operating system and check the \"Dependencies\" section.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | dotnet-install: Installation finished successfully.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2753 add-matcher /run/act/actions/actions-setup-dotnet@v3/.github/csc.json\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2705  Success - Main Setup .NET\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2699  ::set-env:: DOTNET_ROOT=/usr/share/dotnet\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2699  ::set-output:: dotnet-version=9.0.200\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2699  ::add-path:: /usr/share/dotnet\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \u2b50 Run Main Restore dependencies\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/2] user= workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Determining projects to restore...\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Restored /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions/GitBugActions.csproj (in 115 ms).\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Restored /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/GitBugActions.Tests.csproj (in 14.95 sec).\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2705  Success - Main Restore dependencies\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \u2b50 Run Main Build\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/3] user= workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   GitBugActions -> /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions/bin/Debug/net9.0/GitBugActions.dll\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   GitBugActions.Tests -> /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/bin/Debug/net9.0/GitBugActions.Tests.dll\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Build succeeded.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |     0 Warning(s)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |     0 Error(s)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Time Elapsed 00:00:04.01\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2705  Success - Main Build\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \u2b50 Run Main Test\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/4] user= workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Determining projects to restore...\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Writing /tmp/tmpR92zkC.tmp\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : X.509 certificate chain validation will use the fallback certificate bundle at '/usr/share/dotnet/sdk/9.0.200/trustedroots/codesignctl.pem'.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : X.509 certificate chain validation will use the fallback certificate bundle at '/usr/share/dotnet/sdk/9.0.200/trustedroots/timestampctl.pem'.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : Adding PackageReference for package 'JUnitXml.TestLogger' into project '/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/GitBugActions.Tests.csproj'.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : Restoring packages for /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/GitBugActions.Tests.csproj...\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info :   GET https://api.nuget.org/v3-flatcontainer/junitxml.testlogger/index.json\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info :   OK https://api.nuget.org/v3-flatcontainer/junitxml.testlogger/index.json 445ms\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info :   GET https://api.nuget.org/v3-flatcontainer/junitxml.testlogger/5.0.0/junitxml.testlogger.5.0.0.nupkg\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info :   OK https://api.nuget.org/v3-flatcontainer/junitxml.testlogger/5.0.0/junitxml.testlogger.5.0.0.nupkg 418ms\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : Installed JunitXml.TestLogger 5.0.0 from https://api.nuget.org/v3/index.json to /home/runner/.nuget/packages/junitxml.testlogger/5.0.0 with content hash wpmmxsaAmvOylBPMngyjwWdUiG3tu9eouBB9VN/5gbiWvaE6TInbKH8F0IGFIH0zTUaqbx4t4FV1avvC5htpdA==.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info :   CACHE https://api.nuget.org/v3/vulnerabilities/index.json\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info :   CACHE https://api.nuget.org/v3-vulnerabilities/2025.03.07.17.36.10/vulnerability.base.json\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info :   CACHE https://api.nuget.org/v3-vulnerabilities/2025.03.07.17.36.10/2025.03.10.23.36.18/vulnerability.update.json\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : Package 'JUnitXml.TestLogger' is compatible with all the specified frameworks in project '/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/GitBugActions.Tests.csproj'.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : PackageReference for package 'JUnitXml.TestLogger' version '5.0.0' added to file '/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/GitBugActions.Tests.csproj'.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : Generating MSBuild file /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/obj/GitBugActions.Tests.csproj.nuget.g.props.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | info : Writing assets file to disk. Path: /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/obj/project.assets.json\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | log  : Restored /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/GitBugActions.Tests.csproj (in 1.62 sec).\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Determining projects to restore...\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   All projects are up-to-date for restore.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   GitBugActions -> /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions/bin/Debug/net9.0/GitBugActions.dll\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   GitBugActions.Tests -> /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/bin/Debug/net9.0/GitBugActions.Tests.dll\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Build succeeded.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |     0 Warning(s)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |     0 Error(s)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Time Elapsed 00:00:02.02\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Build started 03/11/2025 14:11:13.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |      1>Project \"/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.sln\" on node 1 (VSTest target(s)).\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |      1>ValidateSolutionConfiguration:\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |          Building solution configuration \"Debug|Any CPU\".\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Test run for /tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.Tests/bin/Debug/net9.0/GitBugActions.Tests.dll (.NETCoreApp,Version=v9.0)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | VSTest version 17.12.0 (x64)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Starting test execution, please wait...\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | A total of 1 test files matched the specified pattern.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | [xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.4.5+1caef2f33e (64-bit .NET 9.0.2)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | [xUnit.net 00:00:00.35]   Discovering: GitBugActions.Tests\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | [xUnit.net 00:00:00.38]   Discovered:  GitBugActions.Tests\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | [xUnit.net 00:00:00.39]   Starting:    GitBugActions.Tests\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | [xUnit.net 00:00:00.44]   Finished:    GitBugActions.Tests\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Passed GitBugActions.Tests.AppMathTests.TestSumTwice [3 ms]\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Passed GitBugActions.Tests.AppMathTests.TestSum [< 1 ms]\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Passed GitBugActions.Tests.AppMathTests.TestMultiply [< 1 ms]\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Passed GitBugActions.Tests.AppMathTests.TestSubtract [< 1 ms]\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |   Passed GitBugActions.Tests.AppMathTests.TestSubtractTwice [< 1 ms]\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Results File: TestResults/test-results.xml\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Test Run Successful.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Total tests: 5\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |      Passed: 5\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |  Total time: 0.9581 Seconds\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |      1>Done Building Project \"/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/GitBugActions.sln\" (VSTest target(s)).\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Build succeeded.\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |     0 Warning(s)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   |     0 Error(s)\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | \n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   | Time Elapsed 00:00:01.95\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2705  Success - Main Test\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \u2b50 Run Post Setup .NET\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \ud83d\udc33  docker exec cmd=[node /var/run/act/actions/actions-setup-dotnet@v3/dist/cache-save/index.js] user= workdir=\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build]   \u2705  Success - Post Setup .NET\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] Cleaning up container for job build\n[8cd6e1f4-d5fc-4c56-972a-ca4a847e5870/build] \ud83c\udfc1  Job succeeded\n",
+        "stderr": "time=\"2025-03-11T15:10:21+01:00\" level=info msg=\"Parallel tasks (0) below minimum, setting to 1\"\ntime=\"2025-03-11T15:10:21+01:00\" level=info msg=\"Parallel tasks (0) below minimum, setting to 1\"\n",
+        "workflow": {
+            "path": "/tmp/91796680-fe82-11ef-b2b0-98597a56f496/gitbugactions-gitbugactions-dotnet-test-repo/.github/workflows/tests-crawler.yml",
+            "type": "dotnet"
+        },
+        "workflow_name": "8cd6e1f4-d5fc-4c56-972a-ca4a847e5870",
+        "build_tool": "dotnet",
+        "elapsed_time": 54.941309452056885,
+        "default_actions": false,
+        "return_code": 0
+    }
+}

--- a/test/resources/test_workflows/dotnet/tests.yml
+++ b/test/resources/test_workflows/dotnet/tests.yml
@@ -1,0 +1,28 @@
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 9.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --no-restore
+      
+    - name: Test
+      run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
Closes #227 

To finish this integration, we need to:
- [x] Identify the project directory
- [x] add the junitxml test logger: `dotnet add package JunitXml.TestLogger --version 5.0.0` in that directory
- [x] run the test command with the option `--logger:junit`

This likely requires that the workflow instrumentation can access files other than the workflow itself. This is not currently supported, however.