### PR TITLE
feat: filter on pr

### DIFF
--- a/test/integration_tests/test_collect_bugs.py
+++ b/test/integration_tests/test_collect_bugs.py
@@ -195,6 +195,36 @@ def test_get_possible_patches_pull_requests():
     assert "ff6e2662174af4024eef123b7d23b15192748b31" in commits
 
 
+def test_get_possible_patches_filter_linked_to_pr():
+    # Test filtering for commits linked to PRs
+    collector = PatchCollector(
+        GithubAPI().get_repo("gitbugactions/gitbugactions-maven-test-repo"),
+        filter_on_commit_message=False,
+        filter_linked_to_pr=True,
+    )
+    patches: List[BugPatch] = collector.get_possible_patches()
+    commits = list(map(lambda patch: patch.commit, patches))
+    # This commit is linked to a PR
+    assert "02dc8a4b03c6b6c38f130a6794d9d6dfcc7bff2f" in commits
+    # This commit is not linked to a PR
+    assert "dc71f8ddba909f2c0c58324dd6e2c37a48c35f7f" not in commits
+
+    # Test filtering for commits not linked to PRs
+    collector = PatchCollector(
+        GithubAPI().get_repo("gitbugactions/gitbugactions-maven-test-repo"),
+        filter_on_commit_message=False,
+        filter_linked_to_pr=False,
+    )
+    patches: List[BugPatch] = collector.get_possible_patches()
+    commits = list(map(lambda patch: patch.commit, patches))
+    # This commit is linked to a PR
+    assert "02dc8a4b03c6b6c38f130a6794d9d6dfcc7bff2f" in commits
+    # This commit is not linked to a PR
+    assert "dc71f8ddba909f2c0c58324dd6e2c37a48c35f7f" in commits
+
+    delete_repo_clone(collector.repo_clone)
+
+
 class TestCollectBugs:
     TOKEN_USAGE: int = 0
 


### PR DESCRIPTION
This pull request introduces a new feature to filter commits based on whether they are linked to pull requests in the `collect_bugs.py` file. Additionally, it includes corresponding tests to ensure the new functionality works as expected.

Changes to `collect_bugs.py`:

* Added a new parameter `filter_linked_to_pr` to the `__init__` method to allow filtering commits based on their linkage to pull requests.
* Implemented the filtering logic in the `get_possible_patches` method to exclude commits not linked to pull requests if `filter_linked_to_pr` is set.
* Updated the `collect_bugs` function to include the `filter_linked_to_pr` parameter in its signature and documentation. [[1]](diffhunk://#diff-7bb1f2e9ade87386ec2b5b1d2725c88fa00dfbce102de1e2ddc2d49c2beef64fR449) [[2]](diffhunk://#diff-7bb1f2e9ade87386ec2b5b1d2725c88fa00dfbce102de1e2ddc2d49c2beef64fR470)
* Passed the `filter_linked_to_pr` parameter into the `PatchCollector` initialization within the `collect_bugs` function.

Changes to `test_collect_bugs.py`:

* Added a new test `test_get_possible_patches_filter_linked_to_pr` to verify that the filtering logic correctly includes or excludes commits based on their linkage to pull requests.